### PR TITLE
sync with latest xarray

### DIFF
--- a/environment-ci.yml
+++ b/environment-ci.yml
@@ -21,9 +21,9 @@ dependencies:
   - scipy
   - typer
   - types-setuptools
-  - xarray >= 0.20.2
   - xarray-sentinel >= 0.9.0
   - xmlschema
   - zarr
   - pip:
       - mdformat-gfm
+      - git+https://github.com/pydata/xarray.git

--- a/sarsen/apps.py
+++ b/sarsen/apps.py
@@ -177,7 +177,7 @@ def terrain_correction(
             engine="sentinel-1",
             group=f"{measurement_group}/coordinate_conversion",
             **kwargs,
-        )  # type: ignore
+        )
 
     logger.info("pre-process DEM")
 

--- a/sarsen/apps.py
+++ b/sarsen/apps.py
@@ -142,7 +142,7 @@ def terrain_correction(
             engine="sentinel-1",
             group=f"{measurement_group}/coordinate_conversion",
             **kwargs,
-        )  # type: ignore
+        )
         ground_range = xarray_sentinel.slant_range_time_to_ground_range(
             acquisition.azimuth_time,
             acquisition.slant_range_time,

--- a/sarsen/orbit.py
+++ b/sarsen/orbit.py
@@ -80,11 +80,10 @@ class OrbitPolyfitIterpolator:
         if time is None:
             time = self.azimuth_time_range(**kwargs)
         assert time.dtype.name in ("datetime64[ns]", "timedelta64[ns]")
-        epoch_time = time.assign_coords({time.name: time - self.epoch})  # type: ignore
 
         velocity_coefficients = polyder(self.coefficients) * S_TO_NS
 
         velocity: xr.DataArray
-        velocity = xr.polyval(epoch_time.coords[time.name], velocity_coefficients)  # type: ignore
+        velocity = xr.polyval(time - self.epoch, velocity_coefficients)  # type: ignore
         velocity = velocity.assign_coords({time.name: time})  # type: ignore
         return velocity.rename("velocity")

--- a/sarsen/orbit.py
+++ b/sarsen/orbit.py
@@ -71,7 +71,7 @@ class OrbitPolyfitIterpolator:
         epoch_time = time.assign_coords({time.name: time - self.epoch})  # type: ignore
 
         position: xr.DataArray
-        position = xr.polyval(epoch_time, self.coefficients)  # type: ignore
+        position = xr.polyval(epoch_time.coords[time.name], self.coefficients)  # type: ignore
         position = position.assign_coords({time.name: time})  # type: ignore
         return position.rename("position")
 
@@ -86,6 +86,6 @@ class OrbitPolyfitIterpolator:
         velocity_coefficients = polyder(self.coefficients) * S_TO_NS
 
         velocity: xr.DataArray
-        velocity = xr.polyval(epoch_time, velocity_coefficients)  # type: ignore
+        velocity = xr.polyval(epoch_time.coords[time.name], velocity_coefficients)  # type: ignore
         velocity = velocity.assign_coords({time.name: time})  # type: ignore
         return velocity.rename("velocity")

--- a/sarsen/orbit.py
+++ b/sarsen/orbit.py
@@ -68,10 +68,9 @@ class OrbitPolyfitIterpolator:
         if time is None:
             time = self.azimuth_time_range(**kwargs)
         assert time.dtype.name in ("datetime64[ns]", "timedelta64[ns]")
-        epoch_time = time.assign_coords({time.name: time - self.epoch})  # type: ignore
 
         position: xr.DataArray
-        position = xr.polyval(epoch_time.coords[time.name], self.coefficients)  # type: ignore
+        position = xr.polyval(time - self.epoch, self.coefficients)  # type: ignore
         position = position.assign_coords({time.name: time})  # type: ignore
         return position.rename("position")
 

--- a/sarsen/radiometry.py
+++ b/sarsen/radiometry.py
@@ -45,8 +45,8 @@ def sum_weights(
 
     stacked_geocoded_x_y.data = flat_sum.sel(z=stacked_geocoded.indexes["z"]).data
 
-    weights_sum: xr.DataArray = stacked_geocoded_x_y.unstack("z").rename(
-        z_level_0="slant_range_index", z_level_1="azimuth_index"
+    weights_sum: xr.DataArray = stacked_geocoded_x_y.unstack("z").drop_vars(
+        ("z_level_0", "z_level_1")
     )
 
     return weights_sum

--- a/sarsen/radiometry.py
+++ b/sarsen/radiometry.py
@@ -26,7 +26,9 @@ def sum_weights(
         z=("azimuth_index", "slant_range_index")
     )
 
-    flat_sum = stacked_geocoded.groupby("z").sum()
+    grouped = stacked_geocoded.groupby("z")
+
+    flat_sum = grouped.sum()
 
     if multilook:
         flat_sum = (
@@ -172,7 +174,7 @@ def gamma_weights_nearest(
 
 
 def azimuth_slant_range_grid(
-    measurement_ds: xr.Dataset,
+    measurement_ds: xr.DataArray,
     coordinate_conversion: T.Optional[xr.Dataset] = None,
     grouping_area_factor: T.Tuple[float, float] = (1.0, 1.0),
 ) -> T.Dict[str, T.Any]:

--- a/sarsen/radiometry.py
+++ b/sarsen/radiometry.py
@@ -172,8 +172,8 @@ def gamma_weights_nearest(
 
 
 def azimuth_slant_range_grid(
-    measurement_ds: xr.DataArray,
-    coordinate_conversion: T.Optional[xr.DataArray] = None,
+    measurement_ds: xr.Dataset,
+    coordinate_conversion: T.Optional[xr.Dataset] = None,
     grouping_area_factor: T.Tuple[float, float] = (1.0, 1.0),
 ) -> T.Dict[str, T.Any]:
 

--- a/sarsen/radiometry.py
+++ b/sarsen/radiometry.py
@@ -19,8 +19,8 @@ def sum_weights(
 ) -> xr.DataArray:
     geocoded = initial_weights.assign_coords(
         # Use z_level names for backward compatibility with xarray<=2022.03.0
-        z_level_0=slant_range_index,
-        z_level_1=azimuth_index,
+        z_level_0=azimuth_index,
+        z_level_1=slant_range_index,
     )  # type: ignore
 
     stacked_geocoded_x_y = geocoded.stack(z=("y", "x"))

--- a/sarsen/scene.py
+++ b/sarsen/scene.py
@@ -18,7 +18,7 @@ def open_dem_raster(dem_urlpath: str, **kwargs: T.Any) -> xr.DataArray:
     dem_raster.attrs["long_name"] = "elevation"
     dem_raster.attrs["units"] = "m"
     dem_raster = dem_raster.rename("dem").squeeze(drop=True)
-    return dem_raster  # type: ignore
+    return dem_raster
 
 
 def convert_to_dem_3d(dem_raster: xr.DataArray, dim: str = "axis") -> xr.DataArray:

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     rasterio
     rioxarray
     typer
-    xarray >= 0.20.2
+    xarray > 2022.03.0
     xarray-sentinel >= 0.9.0
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     rasterio
     rioxarray
     typer
-    xarray > 2022.03.0
+    xarray >= 0.20.2
     xarray-sentinel >= 0.9.0
 
 [options.entry_points]


### PR DESCRIPTION
`sarsen` is not compatible with the latest (unreleased) `xarray`.
I was able to report and fix a couple of issues upstream (https://github.com/pydata/xarray/issues/6597, https://github.com/pydata/xarray/issues/6600), but we need to apply a few changes in `sarsen` as well.

I tested with `xarray@main` commit `c34ef8a60227720724e90aa11a6266c0026a812a`, and all tests are successful.

Let me know if you would like me to add an action that (periodically?) runs the CI using the `xarray` version under development.