### PR TITLE
The mock package is not needed as a dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,6 @@ dependencies:
 - flox
 - fsspec
 - gdal
-- mock
 - numpy >= 1.22.0
 - rasterio >= 1.3.0
 - rioxarray

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
 dependencies = [
   "attrs",
   "flox",
-  "mock",
   "numpy",
   "pandas",
   "rasterio",


### PR DESCRIPTION
The unittest.mock package provided by the standard library is actually used in the code.