### PR TITLE
Skip test that gets killed in Salsa CI and on 32-bit architectures.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dev = [
   "cfchecker>=4.1.0",
   "mypy>=1.15.0",
   "pandas-stubs>=1.4.0",
+  "psutil",
   "pytest>=7.0",
   "pytest-cov>=5.0",
   "setuptools>=64.0",

--- a/tests/test_20_sentinel1.py
+++ b/tests/test_20_sentinel1.py
@@ -1,6 +1,8 @@
 import pathlib
+import sys
 
 import numpy as np
+import psutil
 import pytest
 import xarray as xr
 
@@ -18,6 +20,11 @@ DATA_PATHS = [
 GROUPS = ["IW/VV", "IW1/VV"]
 
 
+@pytest.mark.skipif(
+    psutil.virtual_memory().available < (8 * 1024 * 1024 * 1024) or
+    not sys.maxsize > 2**32,
+    reason="Process gets killed"
+)
 @pytest.mark.parametrize("data_path,group", zip(DATA_PATHS, GROUPS))
 def test_Sentinel1SarProduct(data_path: str, group: str) -> None:
     res = sentinel1.Sentinel1SarProduct(data_path, group)


### PR DESCRIPTION
The process gets killed in Salsa CI (GitLab CI for the Debian package) due to limited resources:
```
I: pybuild base:311: cd /build/package/package/.pybuild/cpython3_3.13/build; python3.13 -m pytest tests
============================= test session starts ==============================
platform linux -- Python 3.13.7, pytest-8.4.2, pluggy-1.6.0
rootdir: /build/package/package/.pybuild/cpython3_3.13/build
configfile: pyproject.toml
plugins: typeguard-4.4.4
collected 35 items
tests/test_00_version.py .                                               [  2%]
tests/test_10_chunking.py ...                                            [ 11%]
tests/test_10_datamodel.py .                                             [ 14%]
tests/test_10_orbit.py .....                                             [ 28%]
tests/test_10_scene.py .X..                                              [ 40%]
tests/test_20_geocoding.py ...                                           [ 48%]
tests/test_20_sentinel1.py .Killed
E: pybuild pybuild:389: test: plugin pyproject failed with: exit code=137: cd /build/package/package/.pybuild/cpython3_3.13/build; python3.13 -m pytest tests
dh_auto_test: error: pybuild --test --test-pytest -i python{version} -p 3.13 returned exit code 13
```
https://salsa.debian.org/debian-gis-team/sarsen/-/jobs/8362879

It also fails on 32-bit architectures with limited address space.

The Salsa CI runners have less than 8 GB RAM available, it's unclear how much memory is required. On a system with 64GB RAM the pytest process took up to 16% of memory (~10GB), the threshold may need to be increased further.